### PR TITLE
feat: add utils to fetch api efficiently

### DIFF
--- a/app/config/api.ts
+++ b/app/config/api.ts
@@ -1,0 +1,1 @@
+export const API_ENDPOINT = 'http://3.35.248.3:3000/';

--- a/app/config/api.ts
+++ b/app/config/api.ts
@@ -1,1 +1,24 @@
-export const API_ENDPOINT = 'http://3.35.248.3:3000/';
+import useSWR from 'swr';
+import * as SecureStore from 'expo-secure-store';
+
+export const API_ENDPOINT = 'http://3.38.84.94:3000/api';
+
+type Method = 'GET' | 'POST' | 'PATCH' | 'DELETE';
+export async function callAPI(url: string, method: Method, body: any) {
+  const token = await SecureStore.getItemAsync('token');
+  const res = await fetch(`${API_ENDPOINT}${url}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}` ?? '',
+    },
+    body: JSON.stringify(body),
+  });
+  return res;
+}
+
+export function useGetRequest(url: string) {
+  return useSWR(url, (u: string) =>
+    callAPI(u, 'GET', undefined).then((res) => res.json()),
+  );
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/react-native-vector-icons": "^6.4.9",
     "date-fns": "^2.25.0",
     "expo": "~42.0.1",
+    "expo-secure-store": "~10.2.0",
     "expo-status-bar": "~1.0.4",
     "native-base": "^3.2.1",
     "react": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react-native-web": "~0.13.12",
     "react-navigation": "^4.4.4",
     "styled-components": "^5.3.3",
-    "styled-system": "^5.1.5"
+    "styled-system": "^5.1.5",
+    "swr": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3869,6 +3869,11 @@ depd@~1.1.2:
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+dequal@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
@@ -8012,6 +8017,13 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
+
+swr@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.0.1.tgz#15f62846b87ee000e52fa07812bb65eb62d79483"
+  integrity sha512-EPQAxSjoD4IaM49rpRHK0q+/NzcwoT8c0/Ylu/u3/6mFj/CWnQVjNJ0MV2Iuw/U+EJSd2TX5czdAwKPYZIG0YA==
+  dependencies:
+    dequal "2.0.2"
 
 table@^6.0.9:
   version "6.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4476,6 +4476,11 @@ expo-modules-core@~0.2.0:
   resolved "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-0.2.0.tgz"
   integrity sha512-inpfZ5X/BaTtbj2wG9PA9AC0MN8VyId6KSRlVuEg7+ziurHBy/kKDFxpOddUokhwiln2uhoYPSStJjR/tKypdw==
 
+expo-secure-store@~10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/expo-secure-store/-/expo-secure-store-10.2.0.tgz#561dfea4d6b4d05a738643d80a15403ebe0e515d"
+  integrity sha512-yNahMY3qzEotAYdsE02ps4yGfDay2twasHfsI/7gJB9SrwXYFx5bJuCDk8uTo8jsm6psvDjO+9VMM2DSPHik2A==
+
 expo-status-bar@~1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-1.0.4.tgz"


### PR DESCRIPTION
### Issue number
close: #20 

### Description
api 연동을 위한 유틸을 추가합니다.
[swr](https://swr.vercel.app/ko)는 GET 요청 시 받은 데이터를 캐싱하여 저장하고 간편하게 불러오기 위해 사용했으며, 인증에 사용되는 토큰을 디바이스에 저장하기 위해 [SecureStore](https://docs.expo.dev/versions/latest/sdk/securestore/)모듈을 사용했습니다.

자세한 연동 방법은 [wiki api 연동 탭](https://github.com/mountain-sailors/stock-battle-front/wiki/API-Fetch) 파트에 작성했습니다.

**[NOTICE]**
대부분의 API가 요청 시 인증 토큰을 확인하므로 다른 API보다 먼저 로그인 API를 구현해야 합니다.
로그인 성공 시 token값을 `SecureStore` 에 저장해야 하며 자세한 로직은 아래 예시를 참고해 주세요.

```ts
import * as SecureStore from 'expo-secure-store';
import { callAPI } from '../../config/api';
...
const handlePress = () => {
  callAPI('/user/login', 'POST', {
    email,
    password,
  })
    .then((res) => res.json())
    .then(async (res) => {
      if (res.token) {
        await SecureStore.setItemAsync('token', res.token);
        // 로그인이 성공했을 때
        console.log(res);
      } else if (!res.token) {
        // 로그인이 실패했을 때
        console.log(res);
      }
    });
};
```

### Checklist
- [x] PR 제목은 알맞게 작성되었는가
  - commit convention 형식과 동일한 포맷으로 작성할 것
- [x] assignee가 본인으로 되어있고, lebel은 PR 주제에 맞게 추가했는가
- [x] description에 PR에 대해 구체적으로 설명했는가
