### PR TITLE
feat: add duplicate nickname verification feature

### DIFF
--- a/app/screens/initial/SignupScreen.tsx
+++ b/app/screens/initial/SignupScreen.tsx
@@ -76,20 +76,42 @@ const SignupScreen: React.FC<SignupScreenProp> = ({ navigation, route }) => {
   const registerUser = () => {
     const isValidate = validate();
     if (isValidate === false) return;
-    callAPI('/user', 'POST', {
-      email: email,
-      password: formData.password,
+    callAPI('/user/username', 'POST', {
       username: formData.nickname,
-      avatar: formData.avatarId.toString(),
     })
-      .then()
-      .then(() => {
-        toast.show({
-          status: 'success',
-          title: '회원가입 성공',
-          description: '회원가입이 성공적으로 완료되었습니다.',
-        });
-        navigation.reset({ routes: [{ name: 'Login' }] });
+      .then((res) => res.json())
+      .then((res) => {
+        if (res.isNameExist) {
+          toast.show({
+            status: 'error',
+            title: '닉네임 중복',
+            description: '중복된 닉네임이 존재합니다.',
+          });
+          return;
+        } else {
+          callAPI('/user', 'POST', {
+            email: email,
+            password: formData.password,
+            username: formData.nickname,
+            avatar: formData.avatarId.toString(),
+          })
+            .then(() => {
+              toast.show({
+                status: 'success',
+                title: '회원가입 성공',
+                description: '회원가입이 성공적으로 완료되었습니다.',
+              });
+              navigation.reset({ routes: [{ name: 'Init' }] });
+            })
+            .catch((err) => {
+              console.error(err);
+              toast.show({
+                status: 'error',
+                title: '회원가입 실패',
+                description: '회원가입 도중 문제가 발생했습니다.',
+              });
+            });
+        }
       })
       .catch((err) => {
         console.error(err);

--- a/app/screens/initial/ValidateEmailScreen.tsx
+++ b/app/screens/initial/ValidateEmailScreen.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Spacer,
   FormControl,
+  Text,
   VStack,
 } from 'native-base';
 
@@ -144,6 +145,9 @@ const ValidateEmailScreen: React.FC<ValidateEmailScreenProp> = ({
               setFormData({ ...formData, verifyCode: value })
             }
           />
+          <Text mt={1} fontSize="sm" color="gray.500">
+            메일이 보이지 않는 경우 스팸함을 확인해 주세요.
+          </Text>
           <Button
             variant={formData.verifyCode === '' ? 'ghost' : 'outline'}
             size="md"


### PR DESCRIPTION
### Issue number
close: #56 

### Description
회원가입 시 닉네임 중복 확인 API를 호출하고, 중복이라면 에러 알람을 띄우는 기능을 추가합니다.
추가로 일부 도메인에서 인증번호 메일이 스팸함으로 가는 이슈를 확인해 인증번호 폼에서 이를 안내하는 문구를 추가했습니다. 이건 작업량이 크지 않아 따로 나누지 않았어요.

### Checklist
- [x] PR 제목은 알맞게 작성되었는가
  - commit convention 형식과 동일한 포맷으로 작성할 것
- [x] assignee가 본인으로 되어있고, lebel은 PR 주제에 맞게 추가했는가
- [x] description에 PR에 대해 구체적으로 설명했는가
